### PR TITLE
fixed support to files with spaces in name

### DIFF
--- a/props.py
+++ b/props.py
@@ -20,7 +20,7 @@ class FileEntry(PropertyGroup):
         logline = self.logline
 
         self.name = logline
-        self.ref = logline[3:]
+        self.ref = logline[3:].strip('"')
 
         X,Y = logline[:2]
 


### PR DESCRIPTION
Hey awesome addon! We are using git as versioning in my job. This addon helps the non coders to use git directly  from blender. Fixed file references to ignore quotes so it will work with file names with spaces in windows.